### PR TITLE
defect #2401179: fix bdd scenario file name

### DIFF
--- a/src/commands/download-test.ts
+++ b/src/commands/download-test.ts
@@ -51,8 +51,18 @@ export function registerCommand(context: ExtensionContext) {
 					baseUri = vscode.workspace.workspaceFolders[0].uri;
 			}
 			logger.debug(`Trying to populate download script default location using ${baseUri}`);
+
 			let newFile;
-			newFile = vscode.Uri.joinPath(baseUri, `${e.entity.name}_${e.entity.id}.feature`);
+
+			if (e.entity.subtype === 'scenario_test') {
+				const entity = await service.getDataFromOctaneForTypeAndId(e.entity.type, e.entity.subtype, e.entity.id, [{'name': 'bdd_spec'}]);
+				const parentEntityName = entity.bdd_spec.name;
+				const parentEntityId = entity.bdd_spec.id;
+
+				newFile = vscode.Uri.joinPath(baseUri, `${parentEntityName}_${parentEntityId}.feature`);
+			} else {
+				newFile = vscode.Uri.joinPath(baseUri, `${e.entity.name}_${e.entity.id}.feature`);
+			}
 
 			const fileInfos = await vscode.window.showSaveDialog({ defaultUri: newFile });
 			if (fileInfos) {

--- a/src/octane/service/octane-service.ts
+++ b/src/octane/service/octane-service.ts
@@ -489,16 +489,21 @@ export class OctaneService {
         return this.octaneMap.get(type);
     }
 
-    public async getDataFromOctaneForTypeAndId(type: string | undefined, subType: string | undefined, id: string) {
+    public async getDataFromOctaneForTypeAndId(type: string | undefined, subType: string | undefined, id: string, fields?: any[]) {
         const octaneType = subType || type;
         if (!octaneType) {
             return;
         }
-        const fields = await this.getFieldsForType(octaneType);
+
         if (!fields) {
-            this.logger.error(`Could not determine fields for type ${octaneType}.`);
-            return;
+            fields = await this.getFieldsForType(octaneType);
+
+            if (!fields) {
+                this.logger.error(`Could not determine fields for type ${octaneType}.`);
+                return;
+            }
         }
+
         const apiEntityType = type || subType;
         if (!apiEntityType) {
             return;


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2401179

**Problem:** When downloading the script for BDD Scenario entity, before it was "testName_testId.feature", now it should be "bddSpecTestName_bddSpecTestId.feature", where the bdd spec si the parent of the scenario.

**Solution:** 
- I added a new optional parameter to the method that retrieves all the fields of an entity, so that we can retrieve only the ones that we need (bdd_spec in our case)
- In the download-test file, I changed the logic for the case when we are dealing with BDD Scenario