### PR TITLE
defect #2411005: added full commit message when copying to clipboard

### DIFF
--- a/src/commands/copy-commit-message.ts
+++ b/src/commands/copy-commit-message.ts
@@ -41,6 +41,7 @@ const typeLabels: Map<string, string> = new Map([
 export function registerCommand(context: ExtensionContext) {
     let commitMessageCommand = vscode.commands.registerCommand('visual-studio-code-plugin-for-alm-octane.commitMessage', async (e: MyWorkItem) => {
         let text = '';
+        let commitMessage = 'my commit message';
         if (e.entity && e.entity instanceof Task) {
             let comment = e.entity as Task;
             let labelKey = (comment.story?.subtype && comment.story?.subtype !== '') ? comment.story.subtype : comment.story?.type;
@@ -50,7 +51,7 @@ export function registerCommand(context: ExtensionContext) {
         }
         let labelKey = (e.entity?.subtype && e.entity.subtype !== '') ? e.entity.subtype : e.entity?.type;
         if (labelKey) {
-            text += `${typeLabels.get(labelKey) ?? labelKey} #${e.id}: `;
+            text += `${typeLabels.get(labelKey) ?? labelKey} #${e.id}: ${commitMessage}`;
             await vscode.env.clipboard.writeText(text);
         }
         vscode.window.showInformationMessage('Commit message copied to clipboard.');


### PR DESCRIPTION
[https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2411005](https://center.almoctane.com/ui/?p=1001/1002#/entity-navigation?entityType=work_item&id=2411005)

**Problem:** 

- When user tries to copy commit message to clipboard it will be only copied as "defect #1234", instead of "defect #1234: my commit message". 

- Also if the user tries to copy commit message for a task which has a task parent it will be copied as "user story #1234: task #1234: ",  instead of "user story #1234: task #1234: my commit message".

**Solution:** I added full commit message text in both cases ("defect #1234: my commit message") and (user story #1234: task #1234: my commit message) when user copies message to clipboard.